### PR TITLE
Support (de)serialization of multiple inputs and outputs

### DIFF
--- a/src/python/petab_sciml/specification.py
+++ b/src/python/petab_sciml/specification.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import Any
 
 import ast
 import inspect
@@ -11,7 +12,7 @@ from pydantic import BaseModel, Field
 from mkstd import YamlStandard
 
 
-__all__ = ["Input", "Layer", "Node", "MLModel", "MLModels", "PetabScimlStandard"]
+__all__ = ["Input", "Layer", "Node", "MLModel", "MLModels", "Output", "PetabScimlStandard"]
 
 
 class Input(BaseModel):
@@ -21,6 +22,11 @@ class Input(BaseModel):
     transform: dict | None = Field(
         default=None
     )  # TODO class of supported transforms
+    dim: int
+
+
+class Output(Input):
+    transform: None = None
 
 
 class Layer(BaseModel):
@@ -173,6 +179,51 @@ def get_module_layer_type(module: nn.Module) -> str:
     return type(module).__name__
 
 
+def node_to_str(args: list[Node], pytorch_nodes: list[Node]) -> list[str]:
+    """Convert nodes in layer/method inputs to node names.
+
+    Args:
+        args:
+            The nodes.
+        pytorch_nodes:
+            All PyTorch nodes, from an FX symbolic trace.
+
+    Returns:
+        The converted nodes.
+    """
+    return [str(arg) if arg in pytorch_nodes else arg for arg in args]
+
+
+def str_to_node(all_args: tuple[Any], state: dict[str, Node], index: int | None = None) -> tuple[Any]:
+    """Convert node names in layer inputs to nodes.
+
+    For example, ``torch.stack`` stacks all tensors in its first argument.
+    The first argument is therefore a nested iterable. In this iterable, each tensor
+    will be some node in the preceding computational graph. On disk, these nodes are
+    their names. This substitutes the names for their nodes.
+
+    Args:
+        all_args:
+            All layer/method inputs/arguments, if ``index`` is specified. Otherwise,
+            the nodes.
+        state:
+            The nodes in the computational graph preceding these args.
+            Keys are node names, values are the nodes.
+        index:
+            The index of ``all_args`` that will be converted.
+
+    Returns:
+        The arguments, with conversions only at ``index`` if specified.
+    """
+    if index is None:
+        return tuple([state[arg] if arg in state else arg for arg in all_args])
+    return tuple(
+        list(all_args[:index])
+        + [tuple([state[arg] if arg in state else arg for arg in all_args[index]])]
+        + list(all_args[index+1:])
+    )
+
+
 class MLModel(BaseModel):
     """An easy-to-use format to specify simple deep ML models.
 
@@ -182,6 +233,7 @@ class MLModel(BaseModel):
     mlmodel_id: str
 
     inputs: list[Input]
+    outputs: list[Input]
 
     layers: list[Layer]
     """The components of the model (e.g., layers of a neural network)."""
@@ -190,7 +242,7 @@ class MLModel(BaseModel):
 
     @staticmethod
     def from_pytorch_module(
-        module: nn.Module, mlmodel_id: str, inputs: list[Input]
+        module: nn.Module, mlmodel_id: str, inputs: list[Input], outputs: list[Output],
     ) -> MLModel:
         """Create a PEtab SciML ML model from a pytorch module."""
         layers = []
@@ -208,28 +260,30 @@ class MLModel(BaseModel):
             layer_ids.append(layer_id)
 
         nodes = []
-        node_names = []
         pytorch_nodes = list(torch.fx.symbolic_trace(module).graph.nodes)
         for pytorch_node in pytorch_nodes:
             op = pytorch_node.op
             target = pytorch_node.target
+            args = node_to_str(args=pytorch_node.args, pytorch_nodes=pytorch_nodes)
             if op == "call_function":
                 target = pytorch_node.target.__name__
+                if target == "stack":
+                    args[0] = node_to_str(args=args[0], pytorch_nodes=pytorch_nodes)
+            if op == "output" and isinstance(args[0], tuple):
+                # handle multiple outputs
+                args[0] = node_to_str(args=args[0], pytorch_nodes=pytorch_nodes)
+
             node = Node(
                 name=pytorch_node.name,
-                op=pytorch_node.op,
+                op=op,
                 target=target,
-                args=[
-                    (arg if arg not in pytorch_nodes else str(arg))
-                    for arg in pytorch_node.args
-                ],
+                args=args,
                 kwargs=pytorch_node.kwargs,
             )
             nodes.append(node)
-            node_names.append(node.name)
 
         mlmodel = MLModel(
-            mlmodel_id=mlmodel_id, inputs=inputs, layers=layers, forward=nodes
+            mlmodel_id=mlmodel_id, inputs=inputs, outputs=outputs, layers=layers, forward=nodes
         )
         return mlmodel
 
@@ -268,19 +322,31 @@ class MLModel(BaseModel):
                 case "placeholder":
                     state[node.name] = graph.placeholder(node.target)
                 case "call_function":
-                    if node.target in ["flatten"]:
-                        function = getattr(torch, node.target)
-                    else:
-                        function = getattr(nn.functional, node.target)
+                    call_function_module = nn.functional
+                    if node.target in ["flatten", "stack"]:
+                        call_function_module = torch
+                    function = getattr(call_function_module, node.target)
+                    if node.target in ["stack"]:
+                        args = str_to_node(all_args=args, state=state, index=0)
                     state[node.name] = graph.call_function(
                         function, args, kwargs
+                    )
+                case "call_method":
+                    state[node.name] = graph.call_method(
+                        node.target, args, kwargs
                     )
                 case "call_module":
                     state[node.name] = graph.call_module(
                         node.target, args, kwargs
                     )
                 case "output":
-                    graph.output(args[0])
+                    if isinstance(args[0], list):
+                        args = str_to_node(all_args=args[0], state=state)
+                    else:
+                        args = args[0]
+                    graph.output(args)
+                case _:
+                    raise ValueError(f"Unhandled op: {node.op}")
 
         return torch.fx.GraphModule(_PytorchModule(), graph)
 


### PR DESCRIPTION
Inputs and outputs will be completely defined in the MLModel YAML, with this PR.

- [X] round-trip serialization of multiple inputs and outputs
- [ ] augment inputs/outputs with additional metadata
  - [ ] specific model inputs and outputs (previously specified in mapping/condition table)

Then users only need to "switch on" the ML model by adding the MLModel ID to the conditions table, to fully-specify the hybrid model. The MLModel YAML becomes a full description of how to transform the standard PEtab problem (which has no reference to the MLModel except for the MLModel IDs in the conditions table) into the hybrid model. i.e. the MLModel YAML now has: the NN spec (the forward call); the input mapping; and the output mapping, including information like "pre-ODE", "observable mapping", "ODE".

Pros:
- simpler to understand for users, than having to edit the mapping table and conditions table too
- no need to redefine the NN inputs/outputs multiple times, for each simulation condition the NN is applied to

Cons:
- partially redundant with the v2 conditions/mapping table. However, PEtab SciML tools will need to implement custom NN input/output handlers for e.g. image/array data anyway, because PEtab v2 is currently insufficient for that

I'll work with this for now and see if it makes sense with some examples.