### PR TITLE
Python docs; Read the Docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,23 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  builder: html
+  configuration: docs/conf.py
+  fail_on_warning: False
+
+python:
+  install:
+    - method: pip
+      path: ./src/python
+      extra_requirements:
+        - docs
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.13"

--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,0 +1,2 @@
+_build
+generated

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -1,0 +1,10 @@
+PEtab SciML Python API
+=======================
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree: generated
+
+   petab_sciml
+   petab_sciml.standard

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,0 +1,82 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+from __future__ import annotations
+
+import inspect
+
+import sphinx
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = "PEtab SciML"
+copyright = "2025, The PEtab SciML developers"
+author = "The PEtab SciML developers"
+
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    "readthedocs_ext.readthedocs",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.mathjax",
+    "nbsphinx",
+    "IPython.sphinxext.ipython_console_highlighting",
+    "recommonmark",
+    "sphinx_autodoc_typehints",
+]
+
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+
+intersphinx_mapping = {
+    "petab": (
+        "https://petab.readthedocs.io/projects/libpetab-python/en/latest/",
+        None,
+    ),
+    "pandas": ("https://pandas.pydata.org/docs/", None),
+    "numpy": ("https://numpy.org/devdocs/", None),
+    "python": ("https://docs.python.org/3", None),
+}
+
+autosummary_generate = True
+autodoc_default_options = {
+    "special-members": "__init__",
+    "inherited-members": True,
+}
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = "sphinx_rtd_theme"
+html_static_path = ["standard"]
+# html_logo = "logo/logo-wide.svg"
+
+
+def autodoc_skip_member(app, what, name, obj, skip, options):
+    """Exclude some objects from the documentation."""
+    if inspect.isbuiltin(obj):
+        return True
+
+    # Skip inherited members from builtins
+    #  (skips, for example, all the int/str-derived methods of enums
+    if (
+        objclass := getattr(obj, "__objclass__", None)
+    ) and objclass.__module__ == "builtins":
+        return True
+
+    return None
+
+
+def setup(app: sphinx.application.Sphinx):
+    app.connect("autodoc-skip-member", autodoc_skip_member, priority=0)
+

--- a/doc/format.rst
+++ b/doc/format.rst
@@ -1,0 +1,466 @@
+Format Specification
+====================
+
+A PEtab SciML problem extends the PEtab standard version 2 to
+accommodate hybrid models (SciML problems) that combine neural network
+(NN) and mechanistic components. Two new file types are introduced by
+the extension:
+
+1. `Neural Network File(s) <@ref%20nn_format>`__: Optional YAML file(s)
+   describing NN model(s).
+2. `Hybridization table <@ref%20hybrid_table>`__: Table for assigning NN
+   outputs and inputs.
+
+PEtab SciML further extends the following standard PEtab files:
+
+1. `Mapping Table <@ref%20mapping_table>`__: Extended to describe how NN
+   inputs, outputs and parameters map to PEtab entities.
+2. `Parameters Table <@ref%20parameter_table>`__: Extended to describe
+   nominal values for NN parameters.
+3. `Problem YAML File <@ref%20YAML_file>`__: Extended to include a new
+   SciML field for NN models and (optionally) array or tensor formatted
+   data.
+
+All other PEtab files remain unchanged. This specification explains the
+format for each file that is added or modified by the PEtab SciML
+extension.
+
+`High Level Overview <@id%20hybrid_types>`__
+--------------------------------------------
+
+The PEtab SciML specification is designed to keep the mechanistic model,
+NN model, and PEtab problem as independent as possible while linking
+them through the hybridization and/or condition tables. In this context,
+mechanistic models are typically defined using community standards like
+SBML and are commonly simulated as systems of ordinary differential
+equations (ODEs), and here the terms mechanistic model and ODE are used
+interchangeably. Essentially, the PEtab SciML approach takes a PEtab
+problem involving a mechanistic ODE model and supports the integration
+of NN inputs and outputs.
+
+PEtab SciML supports two classes of hybrid models:
+
+1. **Static hybridization**: For each experimental/simulation condition,
+   inputs are constant and the NN model sets constant parameters and/or
+   initial values in the ODE model prior to model simulation.
+2. **Dynamic hybridization**: The NN model appears in the ODE
+   right-hand-side (RHS) and/or observable formula. Inputs and outputs
+   are computed dynamically over the course of a simulation.
+
+A PEtab SciML problem can also include multiple NNs. Aside from ensuring
+that NNs do not conflict (e.g., by sharing the same output), no special
+considerations are required. Each additional NN is included just as it
+would be in the single NN case.
+
+`NN Model YAML Format <@id%20nn_format>`__
+------------------------------------------
+
+The NN model format is flexible, meaning models can be provided in any
+format compatible with the PEtab SciML specification (for example,
+`Lux.jl <https://github.com/LuxDL/Lux.jl>`__ in
+`PEtab.jl <https://github.com/sebapersson/PEtab.jl>`__). Additionally,
+the ``petab_sciml`` library provides a NN model YAML format that can be
+imported by tools across various programming languages.
+
+!!! tip “For everyone: Use the NN model YAML format for
+interoperability” The NN model specification format in PEtab SciML is
+flexible, to ensure all architectures can be used. However, where
+possible, the NN model YAML format should be used, to facilitate model
+exchange.
+
+A NN model must consist of two parts to be compatible with the PEtab
+SciML specification:
+
+-  **layers**: Defines the NN layers, each with a unique identifier.
+-  **forward**: A forward pass function that, given input arguments,
+   specifies the order in which layers are called, applies any
+   activation functions, and returns one or several arrays. The forward
+   function can accept more than one input argument (``n > 1``), and in
+   the `mapping table <@ref%20mapping_table>`__, the forward function’s
+   ``n``\ th input argument (ignoring any potential class arguments such
+   as ``self``) is referred to as ``inputArgumentIndex{n-1}``. Similar
+   holds for the output. Aside from the NN output values, every
+   component that should be visible to other parts of the PEtab SciML
+   problem must be defined elsewhere (e.g., in **layers**).
+
+`Array data <@id%20hdf5_array>`__
+---------------------------------
+
+The standard PEtab format is unsuitable for incorporating large arrays
+of values into an estimation problem. This includes the large datasets
+used to train NNs, or the parameter values of wide or deep NNs.
+
+Hence, we provide a HDF5-based file format to store and incorporate this
+array data efficiently. Users can choose to provide input data and
+parameter values in a single array data file, or to arbitrarily split
+them across multiple array data files. The general structure is
+
+.. code::
+
+   arrays.hdf5                       # (arbitrary filename)
+   ├── metadata
+   │   └── perm                      # reserved keyword (string). "row" for row-major, "column" for column-major.
+   ├── inputs                        # (optional)
+   │   ├── inputId1
+   │   │   ├─┬─ conditionIds         # (optional) an arbitrary number of PEtab condition IDs (list of string).
+   │   │   │ │  ├── conditionId1 
+   │   │   │ │  └── ... 
+   │   │   │ └── data                # the input data (array).
+   │   │   └── ...
+   │   └── ...
+   └── parameters                    # (optional)
+       ├── netId1
+       │   ├── layerId1
+       │   │   ├── parameterId1      # the parameter values (array).
+       │   │   └── ...
+       │   └── ...
+       └── ...
+
+The schema is provided as `JSON
+schema <standard/array_data_schema.json>`__. Currently, validation is only
+provided via the PEtab SciML library, and does not check the validity of
+framework-specific Ids (e.g. for inputs, parameters, and layers).
+
+!!! tip “Multiple NNs may share the same input array data” Like PEtab
+parameters, NN inputs are global variables. Hence, shared input array
+data for multiple NNs can be specified by using the same input Id in
+each NN. Tools and users should be careful to only intentionally assign
+multiple inputs the same Id.
+
+The Ids of inputs or layer parameters are framework-specific or
+user-specified. For inputs:
+
+-  The PEtab SciML `NN model YAML format <@ref%20NN_YAML>`__ follows
+   PyTorch array dimension indexing. For example, if the first layer is
+   ``Conv2d``, the input should be in ``(C, W, H)`` format.
+-  NN models in other framework-specific formats follow the indexing and
+   naming conventions of the respective framework.
+
+For parameters:
+
+-  The PEtab SciML `NN model YAML format <@ref%20NN_YAML>`__ follows
+   PyTorch indexing and naming conventions. For example, in a PyTorch
+   ``Linear`` layer, the parameter array Ids are ``weight`` and/or
+   ``bias``
+-  NN models in other framework-specific formats follow the indexing and
+   naming conventions of the respective framework.
+
+!!! tip “For developers: Respect memory order” Tools supporting the
+SciML extension should, for computational efficiency, reorder input data
+and potential layer parameter arrays to match the memory ordering of the
+target language. For example, PEtab.jl converts input data to follow
+Julia based indexing.
+
+!!! tip “For developers: Allow export of parameters in PEtab SciML
+format” If the NN is not provided in the YAML format, exchange of NN
+parameters between software is not possible. To facilitate exchange, it
+is recommended that tools supporting PEtab SciML implement a function
+capable of exporting to the PEtab SciML format if all layers in the NN
+correspond to layers supported by the PEtab SciML NN model YAML format.
+
+.. _nn-model-yaml-format-1:
+
+`NN model YAML format <@id%20NN_YAML>`__
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``petab_sciml`` library provides a NN model YAML format for model
+exchange. This format follows PyTorch conventions for layer names and
+arguments. The schema is provided as `JSON
+schema <standard/nn_model_schema.json>`__, which enables validation with
+various third-party tools, and also as `YAML-formatted JSON
+Schema <standard/nn_model_schema.yaml>`__ for readability.
+
+!!! tip “For users: Define models in PyTorch” The recommended approach
+to create a NN model YAML file is to first define a PyTorch model
+(``torch.nn.Module``) and use the Python ``petab_sciml`` library to
+export this to YAML. See the tutorials for examples of this.
+
+`Mapping Table <@id%20mapping_table>`__
+---------------------------------------
+
+All NNs are assigned an identifier in the PEtab problem
+`YAML <@ref%20YAML_file>`__ file. A NN identifier is not considered a
+valid PEtab identifier, to avoid confusion about what it refers to
+(e.g., parameters, inputs, outputs). Consequently, every NN input,
+parameter, and output referenced in the PEtab problem must be defined
+under ``modelEntityId`` and mapped to a PEtab identifier. For the
+``PEtabEntityId`` column the same rules as in PEtab v2 apply.
+Additionally array file Ids defined in the `YAML <@ref%20YAML_file>`__
+file are considered valid PEtab entities.
+
+``modelEntityId`` [STRING, REQUIRED]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A modeling-language-independent syntax which refers to inputs, outputs,
+and parameters of NNs.
+
+`Parameters <@id%20nn_parameters>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The model Id
+``$nnId.parameters[$layerId].{[$arrayId]{[$parameterIndex]}}`` refers to
+the parameters of a NN identified by ``$nnId``.
+
+-  ``$layerId``: The unique identifier of the layer (e.g., ``conv1``).
+-  ``$arrayId``: The parameter array name specific to that layer (e.g.,
+   ``weight``).
+-  ``$parameterIndex``: The indexing into the parameter array
+   (`syntax <@ref%20mapping_table_indexing>`__).
+
+NN parameter PEtab identifiers can only be referenced in the parameters
+table.
+
+`Inputs <@id%20nn_inputs>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The model Id ``$nnId.inputs{[$inputArgumentIndex]{[$inputIndex]}}``
+refers to specific inputs of the NN identified by ``$nnId``.
+
+-  ``$inputArgumentIndex``: The input argument number in the NN forward
+   function. Starts from 0.
+-  ``$inputIndex`` Indexing into the input argument
+   (`syntax <@ref%20mapping_table_indexing>`__). Should not be specified
+   if the input is a file.
+
+For `static hybridization <@ref%20hybrid_types>`__ NN input PEtab
+identifiers are considered valid PETAB_IDs without restrictions (e.g.,
+they may be referenced in the parameters table, condition table,
+hybridization table, etc.). For `dynamic
+hybridization <@ref%20hybrid_types>`__, input PEtab identifiers can only
+be assigned an expression in the `hybridization
+table <@ref%20hybrid_table>`__.
+
+Outputs
+^^^^^^^
+
+The model Id ``$nnId.outputs{[outputArgumentIndex]{[$outputIndex]}}``
+refers to specific outputs of a NN identified by ``$nnId``.
+
+-  ``$outputId``: The output argument number in the NN forward function.
+   Starts from 0.
+-  ``$outputIndex``: Indexing into the output argument
+   (`syntax <@ref%20mapping_table_indexing>`__)
+
+Nested Identifiers
+^^^^^^^^^^^^^^^^^^
+
+The PEtab SciML extension supports nested identifiers for mapping
+structured or hierarchical elements. Identifiers are expressed in the
+hierarchical indicated above using nested curly brackets. Valid examples
+are:
+
+-  ``nn1.parameters``
+-  ``nn1.parameters[conv1]``
+-  ``nn1.parameters[conv1].weight``
+
+!!! warn “Do not break the hierarchy” Identifiers that break the
+hierarchy (e.g., ``nn1.parameters.weight``) are not valid.
+
+`Indexing <@id%20mapping_table_indexing>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Indexing into arrays follows the format ``[i0, i1, ...]``, and indexing
+notation depends on the NN library:
+
+-  NN models in the PEtab SciML `NN model YAML
+   format <@ref%20NN_YAML>`__ follow PyTorch indexing. Consequently,
+   indexing is 0-based.
+-  NN models in other formats follow the indexing and naming conventions
+   of the respective package and programming language.
+
+Assigning Values
+^^^^^^^^^^^^^^^^
+
+For assignments to nested PEtab identifiers (in the ``parameters``,
+``hybridization``, or ``conditions`` tables), assigned values must
+either:
+
+-  Refer to another PEtab identifier with the same nested structure, or
+-  Follow the corresponding hierarchical HDF5
+   `input <@ref%20hdf5_input_structure>`__ or
+   `parameter <@ref%20hdf5_ps_structure>`__ structure.
+
+`Hybridization Table <@id%20hybrid_table>`__
+--------------------------------------------
+
+A tab-separated values file for assigning NN inputs and outputs.
+Assignments in the table the table apply to all simulation conditions.
+Expected to have, in any order, the following two columns:
+
+======================= ===============
+**targetId**            **targetValue**
+======================= ===============
+NON_ESTIMATED_ENTITY_ID MATH_EXPRESSION
+nn1_input1              p1
+nn1_input2              p1
+…                       …
+======================= ===============
+
+Detailed Field Description
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  ``targetId`` [NON_ESTIMATED_ENTITY_ID, REQUIRED]: The identifier of
+   the non-estimated entity that will be modified. Restrictions depend
+   on hybridization type (`static- or dynamic
+   hybridization <@ref%20hybrid_types>`__). See below.
+-  ``targetValue`` [STRING, REQUIRED]: The value or expression that will
+   be used to change the target.
+
+Static hybridization
+~~~~~~~~~~~~~~~~~~~~
+
+Static hybridization NN model inputs and outputs are constant targets
+(case 1 `here <@ref%20hybrid_types>`__).
+
+.. _inputs-1:
+
+Inputs
+^^^^^^
+
+Valid ``targetValue``\ ’s for a NN input are:
+
+-  A parameter in the parameter table.
+-  An array input file (assigned an Id in the `YAML problem
+   file <@ref%20YAML_file>`__).
+
+.. _outputs-1:
+
+Outputs
+^^^^^^^
+
+Valid ``targetId``\ ’s for a NN output are:
+
+-  A non-estimated model parameter.
+-  A species’ initial value (referenced by the species’ Id). In this
+   case, any other species initialization is overridden.
+
+Condition and Hybridization Tables
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+NN input variables are valid ``targetId``\ s for the condition table as
+long as, following the PEtab standard, they are NON_PARAMETER_TABLE_ID.
+**Importantly**, since the hybridization table defines assignments for
+all simulation conditions, any ``targetId`` value in the condition table
+cannot appear in the hybridization table, and vice versa.
+
+NN output variables can also appear in the ``targetValue`` column of the
+condition table.
+
+Dynamic hybridization
+~~~~~~~~~~~~~~~~~~~~~
+
+Dynamic hybridization NN models depend on model simulated model
+quantities (case 2 `here <@ref%20hybrid_types>`__).
+
+.. _inputs-2:
+
+Inputs
+^^^^^^
+
+Valid ``targetValue`` for a NN input is an expression that depend on
+model species, time, and/or parameters. Any model species and/or
+parameters in the expression are expected to be evaluated at the given
+time-value.
+
+.. _outputs-2:
+
+Outputs
+^^^^^^^
+
+Valid ``targetId`` for a NN output is a constant model parameter. During
+PEtab problem import, any assigned parameters is replaced by the NN
+output in the ODE RHS.
+
+`Parameter Table <@id%20parameter_table>`__
+-------------------------------------------
+
+The parameter table follows the same format as in PEtab version 2, with
+a subset of fields extended to accommodate NN parameters. This section
+focuses on columns extended by the SciML extension.
+
+!!! note “Specific Assignments Have Precedence” More specific
+assignments (e.g., ``nnId.parameters[layerId]`` instead of
+``nnId.parameters``) have precedence for nominal values, priors, and
+other setting. For example, if a nominal values is assigned to
+``nnId.parameters`` and a different nominal value is assigned to
+``nnId.parameters[layerId]``, the latter is used.
+
+.. _detailed-field-description-1:
+
+Detailed Field Description
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  ``parameterId`` [String, REQUIRED]: The NN or a specific
+   layer/parameter array id. The target of the ``parameterId`` must be
+   assigned via the `mapping table <@ref%20mapping_table>`__.
+-  ``nominalValue`` [String \| NUMERIC, REQUIRED]: NN nominal values.
+   This can be:
+
+   -  A PEtab variable that via the problem `YAML
+      file <@ref%20YAML_file>`__ corresponds to an HDF5 file with the
+      required `structure <@ref%20hdf5_ps_structure>`__. If no file
+      exists at the given path when the problem is imported and the
+      parameters are set to be estimated, a file is created with
+      randomly sampled values. Unless a numeric value is provided,
+      referring to the same file is required for all assignments for a
+      NN, since all NN parameters should be collected in a single HDF5
+      file following the structure described
+      `here <@ref%20hdf5_ps_structure>`__.
+   -  A numeric value applied to all parameters under ``parameterId``.
+
+-  ``estimate`` [0 \| 1, REQUIRED]: Indicates whether the parameters are
+   estimated (``1``) or fixed (``0``).
+
+Bounds for NN parameters
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Bounds can be specified for an entire NN or its nested identifiers.
+However, most optimization algorithms used for NNs, such as ADAM, do not
+support parameter bounds in their standard implementations. Therefore,
+NN bounds are optional and default to ``-inf`` for the lower bound and
+``inf`` for the upper bound.
+
+`Problem YAML File <@id%20YAML_file>`__
+---------------------------------------
+
+PEtab SciML files are defined within the ``extensions`` section of a
+PEtab YAML file. This section specifies the configuration of NNs and
+optional array files used for simulation or parameter estimation.
+
+Fields
+~~~~~~
+
+``neural_networks`` [REQUIRED]
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A list of NN definitions. Each entry is a mapping with the following
+keys:
+
+-  ``location`` [STRING]: File path to the NN model.
+-  ``format`` [STRING]: Format of the NN. Use ``YAML`` if the model is
+   defined in the `PEtab SciML YAML format <@ref%20NN_YAML>`__. For
+   models defined using external libraries, specify the library name
+   (e.g., ``Lux.jl``, ``equinox.py``). -``dynamic`` [BOOL]: Indicates
+   the hybridization type (see `Hybrid Types <@ref%20hybrid_types>`__):
+
+   -  ``true``: dynamic hybridization
+   -  ``false``: static hybridization
+
+``array_files`` [OPTIONAL]
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A list of array file definitions. Each entry is a mapping with the
+following keys:
+
+-  **``location``** [STRING]: File path to the array file.
+-  **``format``** [STRING]: Format of the file (e.g., ``HDF5``).
+
+Parameter array files must follow the structure described in `HDF5
+Parameter Structure <@ref%20hdf5_ps_structure>`__. Input array files
+must follow the structure described in `HDF5 Input
+Structure <@ref%20hdf5_input_structure>`__.
+
+If a NN is provided in another format than the YAML format, respective
+tool must provide the NN during problem import. Note that regardless of
+NN model format, for exchange purposes the NN model **must** be
+available in a file (not in the main PEtab problem import script).

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,0 +1,31 @@
+PEtab SciML - Scientific Machine Learning Format and Tooling
+============================================================
+
+| Version: |version|
+| Source code: https://github.com/sebapersson/petab_sciml
+
+
+.. include::
+   _static/README.rst
+
+.. toctree::
+   :maxdepth: 3
+   :caption: PEtab SciML file format
+
+   File format specification <format.rst>
+   Supported layers and activation functions <layers.rst>
+   tutorial
+
+.. toctree::
+   :maxdepth: 3
+   :caption: Python package
+
+   API <api.rst>
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/doc/layers.rst
+++ b/doc/layers.rst
@@ -1,0 +1,192 @@
+`Supported Layers and Activation Functions <@id%20layers_activation>`__
+=======================================================================
+
+The PEtab SciML neural network model YAML format supports numerous
+standard neural network layers and activation functions. Layer names and
+associated keyword arguments follow the PyTorch naming scheme. PyTorch
+is used because it is currently the most popular machine learning
+framework, and its comprehensive documentation makes it easy to look up
+details for any specific layer or activation function.
+
+If support is lacking for a layer or activation function you would like
+to see, please file an issue on
+`GitHub <https://github.com/sebapersson/petab_sciml/issues>`__.
+
+The table below lists the supported and tested neural network layers
+along with links to their respective PyTorch documentation.
+Additionally, the table indicates which tools support each layer.
+
++--------------------------------------------------------------+----+---+
+| layer                                                        | PE | A |
+|                                                              | ta | M |
+|                                                              | b. | I |
+|                                                              | jl | C |
+|                                                              |    | I |
++==============================================================+====+===+
+| `Linear <https://pytorch.org/do                              | ✔️ |   |
+| cs/stable/generated/torch.nn.Linear.html#torch.nn.Linear>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `Bilinear <https://pytorch.org/docs/s                        | ✔️ |   |
+| table/generated/torch.nn.Bilinear.html#torch.nn.Bilinear>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `Flatten <https://pytorch.org/docs                           | ✔️ |   |
+| /stable/generated/torch.nn.Flatten.html#torch.nn.Flatten>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `Dropout <https://pytorch.org/docs                           | ✔️ |   |
+| /stable/generated/torch.nn.Dropout.html#torch.nn.Dropout>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `Dropout1d <https://pytorch.org/docs/sta                     | ✔️ |   |
+| ble/generated/torch.nn.Dropout1d.html#torch.nn.Dropout1d>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `Dropout2d <https://pytorch.org/docs/sta                     | ✔️ |   |
+| ble/generated/torch.nn.Dropout2d.html#torch.nn.Dropout2d>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `Dropout3d <https://pytorch.org/docs/sta                     | ✔️ |   |
+| ble/generated/torch.nn.Dropout3d.html#torch.nn.Dropout3d>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `AlphaDropout <https://pytorch.org/docs/stable/ge            | ✔️ |   |
+| nerated/torch.nn.AlphaDropout.html#torch.nn.AlphaDropout>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `Conv1d <https://pytorch.org/do                              | ✔️ |   |
+| cs/stable/generated/torch.nn.Conv1d.html#torch.nn.Conv1d>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `Conv2d <https://pytorch.org/do                              | ✔️ |   |
+| cs/stable/generated/torch.nn.Conv2d.html#torch.nn.Conv2d>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `Conv3d <https://pytorch.org/do                              | ✔️ |   |
+| cs/stable/generated/torch.nn.Conv3d.html#torch.nn.Conv3d>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `ConvTranspose1d <https://pytorch.org/docs/stable/generate   | ✔️ |   |
+| d/torch.nn.ConvTranspose1d.html#torch.nn.ConvTranspose1d>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `ConvTranspose2d <https://pytorch.org/docs/stable/generate   | ✔️ |   |
+| d/torch.nn.ConvTranspose2d.html#torch.nn.ConvTranspose2d>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `ConvTranspose3d <https://pytorch.org/docs/stable/generate   | ✔️ |   |
+| d/torch.nn.ConvTranspose3d.html#torch.nn.ConvTranspose3d>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `MaxPool1d <https://pytorch.org/docs/sta                     | ✔️ |   |
+| ble/generated/torch.nn.MaxPool1d.html#torch.nn.MaxPool1d>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `MaxPool2d <https://pytorch.org/docs/sta                     | ✔️ |   |
+| ble/generated/torch.nn.MaxPool2d.html#torch.nn.MaxPool2d>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `MaxPool3d <https://pytorch.org/docs/sta                     | ✔️ |   |
+| ble/generated/torch.nn.MaxPool3d.html#torch.nn.MaxPool3d>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `AvgPool1d <https://pytorch.org/docs/sta                     | ✔️ |   |
+| ble/generated/torch.nn.AvgPool1d.html#torch.nn.AvgPool1d>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `AvgPool2d <https://pytorch.org/docs/sta                     | ✔️ |   |
+| ble/generated/torch.nn.AvgPool2d.html#torch.nn.AvgPool2d>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `AvgPool3d <https://pytorch.org/docs/sta                     | ✔️ |   |
+| ble/generated/torch.nn.AvgPool3d.html#torch.nn.AvgPool3d>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `LPPool1 <https://pytorch.org/docs/s                         | ✔️ |   |
+| table/generated/torch.nn.LPPool1d.html#torch.nn.LPPool1d>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `LPPool2 <https://pytorch.org/docs/s                         | ✔️ |   |
+| table/generated/torch.nn.LPPool2d.html#torch.nn.LPPool2d>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `LPPool3 <https://pytorch.org/docs/s                         | ✔️ |   |
+| table/generated/torch.nn.LPPool3d.html#torch.nn.LPPool3d>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `Ada                                                         | ✔️ |   |
+| ptiveMaxPool1d <https://pytorch.org/docs/stable/generated/to |    |   |
+| rch.nn.AdaptiveMaxPool1d.html#torch.nn.AdaptiveMaxPool1d>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `Ada                                                         | ✔️ |   |
+| ptiveMaxPool2d <https://pytorch.org/docs/stable/generated/to |    |   |
+| rch.nn.AdaptiveMaxPool2d.html#torch.nn.AdaptiveMaxPool2d>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `Ada                                                         | ✔️ |   |
+| ptiveMaxPool3d <https://pytorch.org/docs/stable/generated/to |    |   |
+| rch.nn.AdaptiveMaxPool3d.html#torch.nn.AdaptiveMaxPool3d>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `Ada                                                         | ✔️ |   |
+| ptiveAvgPool1d <https://pytorch.org/docs/stable/generated/to |    |   |
+| rch.nn.AdaptiveAvgPool1d.html#torch.nn.AdaptiveAvgPool1d>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `Ada                                                         | ✔️ |   |
+| ptiveAvgPool2d <https://pytorch.org/docs/stable/generated/to |    |   |
+| rch.nn.AdaptiveAvgPool2d.html#torch.nn.AdaptiveAvgPool2d>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `Ada                                                         | ✔️ |   |
+| ptiveAvgPool3d <https://pytorch.org/docs/stable/generated/to |    |   |
+| rch.nn.AdaptiveAvgPool3d.html#torch.nn.AdaptiveAvgPool3d>`__ |    |   |
++--------------------------------------------------------------+----+---+
+
+Supported Activation Function
+-----------------------------
+
+The table below lists the supported and tested activation functions
+along with links to their respective PyTorch documentation.
+Additionally, the table indicates which tools support each layer.
+
++--------------------------------------------------------------+----+---+
+| Function                                                     | PE | A |
+|                                                              | ta | M |
+|                                                              | b. | I |
+|                                                              | jl | C |
+|                                                              |    | I |
++==============================================================+====+===+
+| `relu <https://pytorch.org/docs/stable/generate              | ✔️ |   |
+| d/torch.nn.functional.relu.html#torch.nn.functional.relu>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `relu6 <https://pytorch.org/docs/stable/generated/           | ✔️ |   |
+| torch.nn.functional.relu6.html#torch.nn.functional.relu6>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `hardtanh <https://pytorch.org/docs/stable/generated/torch.  | ✔️ |   |
+| nn.functional.hardtanh.html#torch.nn.functional.hardtanh>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `h                                                           | ✔️ |   |
+| ardswish <https://pytorch.org/docs/stable/generated/torch.nn |    |   |
+| .functional.hardswish.html#torch.nn.functional.hardswish>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `selu <https://pytorch.org/docs/stable/generate              | ✔️ |   |
+| d/torch.nn.functional.selu.html#torch.nn.functional.selu>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `leak                                                        | ✔️ |   |
+| y_relu <https://pytorch.org/docs/stable/generated/torch.nn.f |    |   |
+| unctional.leaky_relu.html#torch.nn.functional.leaky_relu>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `gelu <https://pytorch.org/docs/stable/generate              | ✔️ |   |
+| d/torch.nn.functional.gelu.html#torch.nn.functional.gelu>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `tanh                                                        | ✔️ |   |
+| shrink <https://pytorch.org/docs/stable/generated/torch.nn.f |    |   |
+| unctional.tanhshrink.html#torch.nn.functional.tanhshrink>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `softsign <https://pytorch.org/docs/stable/generated/torch.  | ✔️ |   |
+| nn.functional.softsign.html#torch.nn.functional.softsign>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `softplus <https://pytorch.org/docs/stable/generated/torch.  | ✔️ |   |
+| nn.functional.softplus.html#torch.nn.functional.softplus>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `tanh <https://pytorch.org/docs/stable/generate              | ✔️ |   |
+| d/torch.nn.functional.tanh.html#torch.nn.functional.tanh>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `sigmoid <https://pytorch.org/docs/stable/generated/torc     | ✔️ |   |
+| h.nn.functional.sigmoid.html#torch.nn.functional.sigmoid>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `hardsig                                                     | ✔️ |   |
+| moid <https://pytorch.org/docs/stable/generated/torch.nn.fun |    |   |
+| ctional.hardsigmoid.html#torch.nn.functional.hardsigmoid>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `mish <https://pytorch.org/docs/stable/generate              | ✔️ |   |
+| d/torch.nn.functional.mish.html#torch.nn.functional.mish>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `elu <https://pytorch.org/docs/stable/genera                 | ✔️ |   |
+| ted/torch.nn.functional.elu.html#torch.nn.functional.elu>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `celu <https://pytorch.org/docs/stable/generate              | ✔️ |   |
+| d/torch.nn.functional.celu.html#torch.nn.functional.celu>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `softmax <https://pytorch.org/docs/stable/generated/torc     | ✔️ |   |
+| h.nn.functional.softmax.html#torch.nn.functional.softmax>`__ |    |   |
++--------------------------------------------------------------+----+---+
+| `log_sof                                                     | ✔️ |   |
+| tmax <https://pytorch.org/docs/stable/generated/torch.nn.fun |    |   |
+| ctional.log_softmax.html#torch.nn.functional.log_softmax>`__ |    |   |
++--------------------------------------------------------------+----+---+

--- a/doc/standard/array_data_schema.json
+++ b/doc/standard/array_data_schema.json
@@ -1,0 +1,105 @@
+{
+    "$defs": {
+        "ConditionSpecificSingleInputData": {
+            "description": "Condition-specific input data for a single input.",
+            "properties": {
+                "data": {
+                    "items": {
+                        "anyOf": [
+                            {
+                                "type": "array"
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ]
+                    },
+                    "title": "Data",
+                    "type": "array"
+                },
+                "conditionIds": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Conditionids"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "title": "ConditionSpecificSingleInputData",
+            "type": "object"
+        },
+        "Metadata": {
+            "description": "Metadata for array(s).",
+            "properties": {
+                "perm": {
+                    "enum": [
+                        "row",
+                        "column"
+                    ],
+                    "title": "Perm",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "perm"
+            ],
+            "title": "Metadata",
+            "type": "object"
+        },
+        "RootModel_list_ConditionSpecificSingleInputData__": {
+            "items": {
+                "$ref": "#/$defs/ConditionSpecificSingleInputData"
+            },
+            "title": "RootModel[list[ConditionSpecificSingleInputData]]",
+            "type": "array"
+        }
+    },
+    "description": "Multiple arrays.\n\nFor example, data for different inputs for different conditions,\nor values for different parameters of different layers.",
+    "properties": {
+        "metadata": {
+            "$ref": "#/$defs/Metadata"
+        },
+        "inputs": {
+            "additionalProperties": {
+                "$ref": "#/$defs/RootModel_list_ConditionSpecificSingleInputData__"
+            },
+            "default": {},
+            "title": "Inputs",
+            "type": "object"
+        },
+        "parameters": {
+            "additionalProperties": {
+                "additionalProperties": {
+                    "anyOf": [
+                        {
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "type": "object"
+            },
+            "default": {},
+            "title": "Parameters",
+            "type": "object"
+        }
+    },
+    "required": [
+        "metadata"
+    ],
+    "title": "ArrayData",
+    "type": "object"
+}

--- a/doc/standard/nn_model_schema.json
+++ b/doc/standard/nn_model_schema.json
@@ -1,0 +1,136 @@
+{
+    "$defs": {
+        "Input": {
+            "description": "Specify (transformations of) the input layer.",
+            "properties": {
+                "input_id": {
+                    "title": "Input Id",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "input_id"
+            ],
+            "title": "Input",
+            "type": "object"
+        },
+        "Layer": {
+            "description": "Specify layers.",
+            "properties": {
+                "layer_id": {
+                    "title": "Layer Id",
+                    "type": "string"
+                },
+                "layer_type": {
+                    "title": "Layer Type",
+                    "type": "string"
+                },
+                "args": {
+                    "anyOf": [
+                        {
+                            "additionalProperties": true,
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Args"
+                }
+            },
+            "required": [
+                "layer_id",
+                "layer_type"
+            ],
+            "title": "Layer",
+            "type": "object"
+        },
+        "Node": {
+            "description": "A node of the computational graph.\n\ne.g. a node in the forward call of a PyTorch model.\nRef: https://pytorch.org/docs/stable/fx.html#torch.fx.Node",
+            "properties": {
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "op": {
+                    "title": "Op",
+                    "type": "string"
+                },
+                "target": {
+                    "title": "Target",
+                    "type": "string"
+                },
+                "args": {
+                    "anyOf": [
+                        {
+                            "items": {},
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Args"
+                },
+                "kwargs": {
+                    "anyOf": [
+                        {
+                            "additionalProperties": true,
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Kwargs"
+                }
+            },
+            "required": [
+                "name",
+                "op",
+                "target"
+            ],
+            "title": "Node",
+            "type": "object"
+        }
+    },
+    "description": "An easy-to-use format to specify simple deep NN models.\n\nThere is a function to export this to a PyTorch module, or to YAML.",
+    "properties": {
+        "nn_model_id": {
+            "title": "Nn Model Id",
+            "type": "string"
+        },
+        "inputs": {
+            "items": {
+                "$ref": "#/$defs/Input"
+            },
+            "title": "Inputs",
+            "type": "array"
+        },
+        "layers": {
+            "items": {
+                "$ref": "#/$defs/Layer"
+            },
+            "title": "Layers",
+            "type": "array"
+        },
+        "forward": {
+            "items": {
+                "$ref": "#/$defs/Node"
+            },
+            "title": "Forward",
+            "type": "array"
+        }
+    },
+    "required": [
+        "nn_model_id",
+        "inputs",
+        "layers",
+        "forward"
+    ],
+    "title": "NNModel",
+    "type": "object"
+}

--- a/doc/standard/nn_model_schema.yaml
+++ b/doc/standard/nn_model_schema.yaml
@@ -1,0 +1,99 @@
+$defs:
+  Input:
+    description: Specify (transformations of) the input layer.
+    properties:
+      input_id:
+        title: Input Id
+        type: string
+    required:
+    - input_id
+    title: Input
+    type: object
+  Layer:
+    description: Specify layers.
+    properties:
+      layer_id:
+        title: Layer Id
+        type: string
+      layer_type:
+        title: Layer Type
+        type: string
+      args:
+        anyOf:
+        - additionalProperties: true
+          type: object
+        - type: 'null'
+        default: null
+        title: Args
+    required:
+    - layer_id
+    - layer_type
+    title: Layer
+    type: object
+  Node:
+    description: 'A node of the computational graph.
+
+
+      e.g. a node in the forward call of a PyTorch model.
+
+      Ref: https://pytorch.org/docs/stable/fx.html#torch.fx.Node'
+    properties:
+      name:
+        title: Name
+        type: string
+      op:
+        title: Op
+        type: string
+      target:
+        title: Target
+        type: string
+      args:
+        anyOf:
+        - items: {}
+          type: array
+        - type: 'null'
+        default: null
+        title: Args
+      kwargs:
+        anyOf:
+        - additionalProperties: true
+          type: object
+        - type: 'null'
+        default: null
+        title: Kwargs
+    required:
+    - name
+    - op
+    - target
+    title: Node
+    type: object
+description: 'An easy-to-use format to specify simple deep NN models.
+
+
+  There is a function to export this to a PyTorch module, or to YAML.'
+properties:
+  nn_model_id:
+    title: Nn Model Id
+    type: string
+  inputs:
+    items:
+      $ref: '#/$defs/Input'
+    title: Inputs
+    type: array
+  layers:
+    items:
+      $ref: '#/$defs/Layer'
+    title: Layers
+    type: array
+  forward:
+    items:
+      $ref: '#/$defs/Node'
+    title: Forward
+    type: array
+required:
+- nn_model_id
+- inputs
+- layers
+- forward
+title: NNModel
+type: object

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -1,0 +1,14 @@
+Tutorial
+========
+
+The tutorials will consist of:
+
+1. Overarching tutorial where we show how to implement the
+   Lotka-Volterra problem from the UDE paper.
+2. Extended tutorial 1 where we have a neural-network setting
+   parameters, here it is also worthwhile to consider simulation
+   conditions.
+3. Extended tutorial 2 where we have a neural network in the observable
+   function.
+
+If time, add tutorial for having two neural networks.

--- a/src/python/petab_sciml/standard/nn_model.py
+++ b/src/python/petab_sciml/standard/nn_model.py
@@ -292,8 +292,8 @@ if __name__ == "__main__":
 
 
     # The NN model file is YAML-formatted, so the schema is provided in YAML format.
-    NNModelStandard.save_schema(Path(__file__).resolve().parents[4] / "docs" / "src" / "assets" / "nn_model_schema.yaml")
+    NNModelStandard.save_schema(Path(__file__).resolve().parents[4] / "doc" / "standard" / "nn_model_schema.yaml")
 
     # However, the schema format is JsonSchema, so the schema is also provided redundantly in JSON schema.
     NNModelStandardJson = JsonStandard(model=NNModel)
-    NNModelStandardJson.save_schema(Path(__file__).resolve().parents[4] / "docs" / "src" / "assets" / "nn_model_schema.json")
+    NNModelStandardJson.save_schema(Path(__file__).resolve().parents[4] / "doc" / "standard" / "nn_model_schema.json")

--- a/src/python/pyproject.toml
+++ b/src/python/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-docs = [
+doc = [
     "sphinx>=8.1.3",
     "sphinxcontrib-napoleon>=0.7",
     "sphinx-markdown-tables>=0.0.15",

--- a/src/python/pyproject.toml
+++ b/src/python/pyproject.toml
@@ -21,6 +21,25 @@ classifiers = [
   "Programming Language :: Python"
 ]
 
+[project.optional-dependencies]
+docs = [
+    "sphinx>=8.1.3",
+    "sphinxcontrib-napoleon>=0.7",
+    "sphinx-markdown-tables>=0.0.15",
+    "sphinx-rtd-theme>=0.5.1",
+    "recommonmark>=0.7.1",
+    # pin until ubuntu comes with newer pandoc:
+    # site-packages/nbsphinx/__init__.py:1058: RuntimeWarning: You are using an unsupported version of pandoc (2.9.2.1).
+    # Your version must be at least (2.14.2) but less than (4.0.0).
+    "nbsphinx>=0.9.5",
+    "pandoc>=2.4",
+    "nbconvert>=7.16.4",
+    "ipykernel>= 6.23.1",
+    "ipython>=7.21.0",
+    "readthedocs-sphinx-ext>=2.2.5",
+    "sphinx-autodoc-typehints",
+]
+
 [project.urls]
 Repository = "https://github.com/sebapersson/petab_sciml"
 "Bug Tracker" = "https://github.com/sebapersson/petab_sciml/issues"


### PR DESCRIPTION
For now, just the structure and most content. I'll look over the documentation in detail in a future PR, but for now, here is something we can build on.
- moves documentation to be Python-based (Sphinx)
- sets up read the docs